### PR TITLE
[Improvement][WIP] add lesion option in WM segmentation

### DIFF
--- a/modules/nf-scil/segmentation/fastseg/main.nf
+++ b/modules/nf-scil/segmentation/fastseg/main.nf
@@ -3,11 +3,11 @@ process SEGMENTATION_FASTSEG {
     label 'process_single'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://scil.usherbrooke.ca/containers/scilus_2.0.0.sif':
-        'scilus/scilus:2.0.0' }"
+        'https://scil.usherbrooke.ca/containers/scilus_2.0.2.sif':
+        'scilus/scilus:2.0.2' }"
 
     input:
-        tuple val(meta), path(image)
+        tuple val(meta), path(image), path(lesion)
 
     output:
         tuple val(meta), path("*mask_wm.nii.gz")                , emit: wm_mask
@@ -38,9 +38,14 @@ process SEGMENTATION_FASTSEG {
     mv t1_pve_1.nii.gz ${prefix}__map_gm.nii.gz
     mv t1_pve_0.nii.gz ${prefix}__map_csf.nii.gz
 
+    if [[ -f "$lesion" ]];
+    then
+        scil_volume_math.py union ${prefix}__mask_wm.nii.gz $lesion ${prefix}__mask_wm.nii.gz --data_type uint8 -f
+    fi
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        scilpy: 2.0.0
+        scilpy: 2.0.2
         fsl: \$(flirt -version 2>&1 | sed -n 's/FLIRT version \\([0-9.]\\+\\)/\\1/p')
     END_VERSIONS
     """

--- a/modules/nf-scil/segmentation/fastseg/meta.yml
+++ b/modules/nf-scil/segmentation/fastseg/meta.yml
@@ -26,6 +26,11 @@ input:
       description: Nifti T1 volume to segment into tissue maps.
       pattern: "*.{nii,nii.gz}"
 
+  - lesion:
+      type: file
+      description: Nifti lesion volume to correct the white matter with a lesion mask.
+      pattern: "*.{nii,nii.gz}"
+
 output:
   - meta:
       type: map

--- a/modules/nf-scil/segmentation/fastseg/meta.yml
+++ b/modules/nf-scil/segmentation/fastseg/meta.yml
@@ -1,7 +1,7 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/scilus/nf-scil/main/modules/meta-schema.json
 name: "segmentation_fastseg"
-description: Perform Brain Tissues Segmentation using FSL fast on a T1 image.
+description: Perform Brain Tissues Segmentation using FSL fast on a T1 image. Optionally, a binary mask of lesion can be add to correct the white matter mask.
 keywords:
   - Segmentation
   - T1
@@ -28,7 +28,7 @@ input:
 
   - lesion:
       type: file
-      description: Nifti lesion volume to correct the white matter with a lesion mask.
+      description: Nifti lesion volume to correct the white matter with a lesion mask. The lesion mask must be a binary mask.
       pattern: "*.{nii,nii.gz}"
 
 output:

--- a/modules/nf-scil/segmentation/fastseg/tests/main.nf.test
+++ b/modules/nf-scil/segmentation/fastseg/tests/main.nf.test
@@ -28,14 +28,14 @@ nextflow_process {
     }
 
     test("segmentation - fastseg") {
-
         when {
             process {
                 """
                 input[0] = LOAD_DATA.out.test_data_directory.map{
                     test_data_directory -> [
                         [ id:'test', single_end:false ], // meta map
-                        file("\${test_data_directory}/anat/anat_image.nii.gz", checkIfExists: true)
+                        file("\${test_data_directory}/anat/anat_image.nii.gz", checkIfExists: true,),
+                        []
                     ]
                 }
                 """
@@ -48,6 +48,27 @@ nextflow_process {
                 { assert snapshot(process.out).match() }
             )
         }
+    }
+    test("segmentation - fastseg - lesion") {
+        when {
+            process {
+                """
+                input[0] = LOAD_DATA.out.test_data_directory.map{
+                    test_data_directory -> [
+                        [ id:'test', single_end:false ], // meta map
+                        file("\${test_data_directory}/anat/anat_image.nii.gz", checkIfExists: true,),
+                        file("\${test_data_directory}/anat/anat_mask.nii.gz", checkIfExists: true)
+                    ]
+                }
+                """
+            }
+        }
 
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
     }
 }

--- a/modules/nf-scil/segmentation/fastseg/tests/main.nf.test.snap
+++ b/modules/nf-scil/segmentation/fastseg/tests/main.nf.test.snap
@@ -1,4 +1,129 @@
 {
+    "segmentation - fastseg - lesion": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__mask_wm.nii.gz:md5,2b2ced42fcf870d68ff44bf90d2701d4"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__mask_gm.nii.gz:md5,39396421c6d1d32ea7943a5ec7a49dce"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__mask_csf.nii.gz:md5,d0fbc088059f17faff38fbcd33257d27"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__map_wm.nii.gz:md5,1d5a9655d4e3c832b14c83e9424b00fc"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__map_gm.nii.gz:md5,f7e51eb14af645c687db5d2c6a4f5bf4"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__map_csf.nii.gz:md5,9c14d8f70e69d641d9c214d0d52b3663"
+                    ]
+                ],
+                "6": [
+                    "versions.yml:md5,d42da2620c5aa82292375b0f9d8d7092"
+                ],
+                "csf_map": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__map_csf.nii.gz:md5,9c14d8f70e69d641d9c214d0d52b3663"
+                    ]
+                ],
+                "csf_mask": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__mask_csf.nii.gz:md5,d0fbc088059f17faff38fbcd33257d27"
+                    ]
+                ],
+                "gm_map": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__map_gm.nii.gz:md5,f7e51eb14af645c687db5d2c6a4f5bf4"
+                    ]
+                ],
+                "gm_mask": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__mask_gm.nii.gz:md5,39396421c6d1d32ea7943a5ec7a49dce"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,d42da2620c5aa82292375b0f9d8d7092"
+                ],
+                "wm_map": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__map_wm.nii.gz:md5,1d5a9655d4e3c832b14c83e9424b00fc"
+                    ]
+                ],
+                "wm_mask": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__mask_wm.nii.gz:md5,2b2ced42fcf870d68ff44bf90d2701d4"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-06-17T13:59:58.264241"
+    },
     "segmentation - fastseg": {
         "content": [
             {
@@ -57,7 +182,7 @@
                     ]
                 ],
                 "6": [
-                    "versions.yml:md5,e9c2afb5537207544dc1b54cbdc389a4"
+                    "versions.yml:md5,d42da2620c5aa82292375b0f9d8d7092"
                 ],
                 "csf_map": [
                     [
@@ -96,7 +221,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,e9c2afb5537207544dc1b54cbdc389a4"
+                    "versions.yml:md5,d42da2620c5aa82292375b0f9d8d7092"
                 ],
                 "wm_map": [
                     [
@@ -122,6 +247,6 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-01T15:30:44.012472"
+        "timestamp": "2024-06-13T19:52:04.291343"
     }
 }

--- a/modules/nf-scil/segmentation/freesurferseg/main.nf
+++ b/modules/nf-scil/segmentation/freesurferseg/main.nf
@@ -7,7 +7,7 @@ process SEGMENTATION_FREESURFERSEG {
         'scilus/scilus:2.0.0' }"
 
     input:
-        tuple val(meta), path(aparc_aseg), path(wmparc)
+        tuple val(meta), path(aparc_aseg), path(wmparc), path(lesion)
 
     output:
         tuple val(meta), path("*__mask_wm.nii.gz")              , emit: wm_mask
@@ -79,6 +79,11 @@ process SEGMENTATION_FREESURFERSEG {
     scil_volume_math.py convert ${prefix}__mask_wm.nii.gz ${prefix}__mask_wm.nii.gz --data_type uint8 -f
     scil_volume_math.py convert ${prefix}__mask_gm.nii.gz ${prefix}__mask_gm.nii.gz --data_type uint8 -f
     scil_volume_math.py convert ${prefix}__mask_csf.nii.gz ${prefix}__mask_csf.nii.gz --data_type uint8 -f
+
+    if [[ -f "$lesion" ]];
+    then
+        scil_volume_math.py union ${prefix}__mask_wm.nii.gz $lesion ${prefix}__mask_wm.nii.gz --data_type uint8 -f
+    fi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-scil/segmentation/freesurferseg/meta.yml
+++ b/modules/nf-scil/segmentation/freesurferseg/meta.yml
@@ -1,6 +1,6 @@
 ---
 name: "segmentation_freesurferseg"
-description: Performs Brain Tissues Segmentation using the FreeSurfer aparc and wmparc output files.
+description: Performs Brain Tissues Segmentation using the FreeSurfer aparc and wmparc output files.  Optionally, a binary mask of lesion can be add to correct the white matter mask.
 keywords:
   - FreeSurfer
   - Segmentation
@@ -32,7 +32,7 @@ input:
 
   - lesion:
       type: file
-      description: Nifti lesion volume to correct the white matter with a lesion mask.
+      description: Nifti lesion volume to correct the white matter with a lesion mask.  The lesion mask must be a binary mask.
       pattern: "*.{nii,nii.gz}"
 
 output:

--- a/modules/nf-scil/segmentation/freesurferseg/meta.yml
+++ b/modules/nf-scil/segmentation/freesurferseg/meta.yml
@@ -30,6 +30,11 @@ input:
       description: FreeSurfer WM parcellation output file.
       pattern: "*.mgz"
 
+  - lesion:
+      type: file
+      description: Nifti lesion volume to correct the white matter with a lesion mask.
+      pattern: "*.{nii,nii.gz}"
+
 output:
   - meta:
       type: map

--- a/modules/nf-scil/segmentation/freesurferseg/tests/main.nf.test
+++ b/modules/nf-scil/segmentation/freesurferseg/tests/main.nf.test
@@ -34,7 +34,8 @@ nextflow_process {
                     test_data_directory -> [
                         [ id:'test', single_end:false ], // meta map
                         file("\${test_data_directory}/freesurfer/aparc_aseg.nii.gz", checkIfExists: true),
-                        file("\${test_data_directory}/freesurfer/wmparc.nii.gz", checkIfExists: true)
+                        file("\${test_data_directory}/freesurfer/wmparc.nii.gz", checkIfExists: true),
+                        []
                     ]
                 }
                 """
@@ -47,6 +48,29 @@ nextflow_process {
                 { assert snapshot(process.out).match() }
             )
         }
+    }
 
+    test("segmentation - freesurferseg - lesion") {
+        when {
+            process {
+                """
+                input[0] = LOAD_DATA.out.test_data_directory.map{
+                    test_data_directory -> [
+                        [ id:'test', single_end:false ], // meta map
+                        file("\${test_data_directory}/freesurfer/aparc_aseg.nii.gz", checkIfExists: true),
+                        file("\${test_data_directory}/freesurfer/wmparc.nii.gz", checkIfExists: true),
+                        [],
+                    ]
+                }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
     }
 }

--- a/modules/nf-scil/segmentation/freesurferseg/tests/main.nf.test.snap
+++ b/modules/nf-scil/segmentation/freesurferseg/tests/main.nf.test.snap
@@ -1,4 +1,75 @@
 {
+    "segmentation - freesurferseg - lesion": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__mask_wm.nii.gz:md5,2dc635526adb6ef185300acc326ead13"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__mask_gm.nii.gz:md5,247106ed727133078fe262b0b8244071"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__mask_csf.nii.gz:md5,b92db7e454c95afadea320a143912ce8"
+                    ]
+                ],
+                "3": [
+                    "versions.yml:md5,dd077c4856c884d1e8ce02900eaf4163"
+                ],
+                "csf_mask": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__mask_csf.nii.gz:md5,b92db7e454c95afadea320a143912ce8"
+                    ]
+                ],
+                "gm_mask": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__mask_gm.nii.gz:md5,247106ed727133078fe262b0b8244071"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,dd077c4856c884d1e8ce02900eaf4163"
+                ],
+                "wm_mask": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__mask_wm.nii.gz:md5,2dc635526adb6ef185300acc326ead13"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-06-17T17:23:13.311367"
+    },
     "segmentation - freesurferseg": {
         "content": [
             {

--- a/subworkflows/nf-scil/anatomical_segmentation/tests/main.nf.test
+++ b/subworkflows/nf-scil/anatomical_segmentation/tests/main.nf.test
@@ -35,7 +35,8 @@ nextflow_workflow {
                 input[0] = LOAD_DATA.out.test_data_directory.map{
                     test_data_directory -> [
                         [ id:'test', single_end:false ], // meta map
-                        file("\${test_data_directory}/anat/anat_image.nii.gz", checkIfExists: true)
+                        file("\${test_data_directory}/anat/anat_image.nii.gz", checkIfExists: true),
+                        []
                     ]}
                 input[1] = []
                 """
@@ -60,7 +61,8 @@ nextflow_workflow {
                     test_data_directory -> [
                         [ id:'test', single_end:false ], // meta map
                         file("\${test_data_directory}/freesurfer/aparc_aseg.nii.gz", checkIfExists: true),
-                        file("\${test_data_directory}/freesurfer/wmparc.nii.gz", checkIfExists: true)
+                        file("\${test_data_directory}/freesurfer/wmparc.nii.gz", checkIfExists: true),
+                        []
                     ]}
                 """
             }

--- a/subworkflows/nf-scil/anatomical_segmentation/tests/main.nf.test.snap
+++ b/subworkflows/nf-scil/anatomical_segmentation/tests/main.nf.test.snap
@@ -146,7 +146,7 @@
                     ]
                 ],
                 "6": [
-                    "versions.yml:md5,0d100de62a24580c4abbed9193fb6352"
+                    "versions.yml:md5,f098240b7d7f6df9a2a43215c5828669"
                 ],
                 "csf_map": [
                     [
@@ -185,7 +185,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,0d100de62a24580c4abbed9193fb6352"
+                    "versions.yml:md5,f098240b7d7f6df9a2a43215c5828669"
                 ],
                 "wm_map": [
                     [
@@ -211,6 +211,6 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-04-30T23:43:22.788057"
+        "timestamp": "2024-06-17T14:24:57.988893"
     }
 }


### PR DESCRIPTION
## Describe your changes

Add the option to add a binary lesion mask to the WM segmentation to fill the WM mask.

## List test packages used by your module

- `heavy.zip`

## Checklist before requesting a review

- Create the tool:
  - [x] Edit `./modules/nf-scil/<category>/<tool>/main.nf`
  - [x] Edit `./modules/nf-scil/<category>/<tool>/meta.yml`
- Generate the tests:
  - [x] Edit `./tests/modules/nf-scil/<category>/<tool>/main.nf`
  - [x] Edit `./tests/modules/nf-scil/<category>/<tool>/nextflow.config`
  - [x] Add test data locally for tests with the fork repository
  - [x] Generate the test infrastructure and _md5sum_ for all outputs
- Ensure the syntax is correct :
  - [x] Check indentation abides with the rest of the library (don't hesitate to correct others !)
  - [x] Lint everything. Ensure your variables have good names.

## To Do 
- Add WM binary mask in the same space than wmparc.nii.gz and aparc_aseg.nii.gz in heavy.zip for freesurgerseg test 