### PR TITLE
[FIX] Detached HEAD problem with nf-core commands

### DIFF
--- a/.devcontainer/updateContentCommand.sh
+++ b/.devcontainer/updateContentCommand.sh
@@ -2,8 +2,14 @@
 
 
 GIT_REMOTE=$(git remote get-url origin)
+CURRENT_BRANCH=
 # Get tracked remote branch associated to current branch (default to main)
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo "main")
+{
+    git rev-parse --abbrev-ref --symbolic-full-name  @{u} 2>/dev/null &&
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref @{u} 2>/dev/null)
+} || {
+    CURRENT_BRANCH="main"
+}
 
 cat <<EOF > $XDG_CONFIG_HOME/nf-scil/.env
 # This file is used to store environment variables for the project.


### PR DESCRIPTION
## Bug category

- [x] Critical (some functionalities is not working at all)
- [ ] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

Inside the **devcontainer**, `nf-core` commands that clone the repository in their actions are affected by the new `environment variables` for **git-remote** and **branch**. It is caused by a bad specification of the branch when building the devcontainer, fetching the **remote** name instead of the local one.

This fixes it. First, it checks if there is a remote branch associated to the current one in the repository. If there is, it specifies the local branch name. Else, because the clone that `nf-core` creates on his side does not have copies the **local branches**, it simply specifies `main`.

## Steps to reproduce the bug

1. Ensure your devcontainer is fully up-to-date with the `main` (not this PR!). If you cannot reproduce, delete all containers and volumes associated to it (their names should start with `nf-scil`) and rebuild.
2. Check your environment variables with `env | grep NFCORE` and verify the branch variables points to remote names
3. Call `nf-core --verbose modules test denoise/mppca --once`. After the repo clone is done, you can `ctrl+c`, no need to wait
4. Call the command again, git commands called by `nf-core` should lead to an error
