### PR TITLE
[IMPROVEMENT] Add nft-nifti plugin for testing

### DIFF
--- a/nf-test.config
+++ b/nf-test.config
@@ -12,4 +12,10 @@ config {
     profile ""
 
     ignore ".venv/**/*.nf.test"
+
+    plugins {
+        repository "https://raw.githubusercontent.com/scilus/nf-scil/main/plugins.json"
+
+        load "nft-nifti@0.0.1"
+    }
 }

--- a/plugins.json
+++ b/plugins.json
@@ -1,13 +1,17 @@
-[{
-    "id": "nft-nifti",
-    "latest": "0.0.1",
-    "url": "https://github.com/scilus/nft-nifti",
-    "github": "scilus/nft-nifti",
-    "description": "Provides support for NIFTI files.",
-    "author": "Arnaud Boré",
-    "keywords": [],
-    "releases": [{
-        "version": "0.0.1",
-        "url": "https://github.com/scilus/nft-nifti/releases/download/0.0.1/nft-nifti-0.0.1.jar"
-    }]
-}]
+[
+    {
+        "id": "nft-nifti",
+        "latest": "0.0.1",
+        "url": "https://github.com/scilus/nft-nifti",
+        "github": "scilus/nft-nifti",
+        "description": "Provides support for NIFTI files.",
+        "author": "Arnaud Boré",
+        "keywords": [],
+        "releases": [
+            {
+                "version": "0.0.1",
+                "url": "https://github.com/scilus/nft-nifti/releases/download/0.0.1/nft-nifti-0.0.1.jar"
+            }
+        ]
+    }
+]

--- a/plugins.json
+++ b/plugins.json
@@ -8,6 +8,6 @@
     "keywords": [],
     "releases": [{
         "version": "0.0.1",
-        "url": "https://github.com/scilus/nft-nifti/releases/download/v0.0.1/nft-nifti-0.0.1.jar"
+        "url": "https://github.com/scilus/nft-nifti/releases/download/0.0.1/nft-nifti-0.0.1.jar"
     }]
 }]


### PR DESCRIPTION
## Type of improvement

**If submitting a new module or fixing a bug, please use the appropriate template.**

- [x] Documentation
- [x] Development tools (e.g. linter, formatter, etc.)
- [ ] Development container
- [ ] Global update (please specify)
- [ ] Other (please specify)

## Describe your improvement

Add the `nft-nifti` plugin developed by @arnaudbore to nf-test. It enables the `Nifti_md5sum` method, that takes a filename and outputs a reproducible md5sum from it. 

## Describe how to test your improvement

Provide a full step-by-step guide to test your improvement.

## Checklist before requesting a review

- [x] Ensure the syntax is correct (**EditorConfig** and **Prettier** must pass)
- [x] Run the test suites if your changes affect any module
- [x] Regenerate the **Poetry** lock file if you have updated the dependencies
- [ ] Ensure the documentation is up-to-date
