### PR TITLE
matrix strategy to not run easyreg when absent

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -121,17 +121,15 @@ jobs:
       fail-fast: false
       matrix:
         path: [ "${{ fromJson(needs.nf-test-changes.outputs.paths) }}" ]
-        include:
-          - profile: docker
-          - runner: scilus-nf-scil-runners
-          - path: modules/nf-scil/registration/easyreg
-            profile: dummy-to-remove
-          - runner: scilus-nf-scil-bigmem-runners
-            path: modules/nf-scil/registration/easyreg
+        profile: [ "docker" ]
         exclude:
           - path: subworkflows/nf-scil/load_test_data
+        include:
+          - runner: scilus-nf-scil-runners
           - path: modules/nf-scil/registration/easyreg
-            profile: dummy-to-remove
+            profile: do-not-run
+          - runner: scilus-nf-scil-bigmem-runners
+            path: modules/nf-scil/registration/easyreg
     uses: ./.github/workflows/nf-test_module.yml
     with:
       profile: ${{ matrix.profile }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -124,10 +124,14 @@ jobs:
         include:
           - profile: docker
           - runner: scilus-nf-scil-runners
+          - path: modules/nf-scil/registration/easyreg
+            profile: dummy-to-remove
           - runner: scilus-nf-scil-bigmem-runners
             path: modules/nf-scil/registration/easyreg
         exclude:
           - path: subworkflows/nf-scil/load_test_data
+          - path: modules/nf-scil/registration/easyreg
+            profile: dummy-to-remove
     uses: ./.github/workflows/nf-test_module.yml
     with:
       profile: ${{ matrix.profile }}

--- a/.github/workflows/nf-test_module.yml
+++ b/.github/workflows/nf-test_module.yml
@@ -45,7 +45,7 @@ jobs:
   nf-test:
     runs-on: ${{ inputs.runner }}
     name: nf-test-${{ inputs.paths }}
-    if: inputs.paths != ''
+    if: inputs.paths != '' && inputs.profile != 'do-not-run'
     env:
       NXF_ANSI_LOG: false
       NFTEST_VER: "0.9.0-rc1"


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [ ] Major (something is not working as expected)
- [x] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

Easyreg tests run all the time. I fixed the matrix, it's a bit of a pain, but no choice. 

## Steps to reproduce the bug

We'll see if it triggers on this PR
