### PR TITLE
[BUGFIX] Prevent nf-test asking more memory than available on runners

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,7 +51,7 @@ jobs:
         run: editorconfig-checker -exclude README.md $(git ls-files | grep -v test)
 
   nf-test-changes:
-    name: nf-test-changes
+    name: compute - changes
     runs-on: ubuntu-latest
     outputs:
       paths: ${{ steps.changes.outputs.components }}
@@ -82,7 +82,7 @@ jobs:
           echo ${{ steps.components.outputs.subworkflows }}
 
   lint-modules:
-    name: lint-modules
+    name: lint - modules
     needs: [nf-test-changes]
     if: ${{ (needs.nf-test-changes.outputs.modules != '[]') }}
     strategy:
@@ -98,7 +98,7 @@ jobs:
     secrets: inherit
 
   lint-subworkflows:
-    name: lint-subworkflows
+    name: lint - subworkflows
     needs: [nf-test-changes]
     if: ${{ ( needs.nf-test-changes.outputs.subworkflows != '[]') }}
     strategy:
@@ -114,7 +114,7 @@ jobs:
     secrets: inherit
 
   nf-test:
-    name: nf-test
+    name: test
     needs: [nf-test-changes]
     if: ${{ ( needs.nf-test-changes.outputs.paths != '[]' ) }}
     strategy:
@@ -136,6 +136,7 @@ jobs:
     secrets: inherit
 
   confirm-pass:
+    name: status
     runs-on: ubuntu-latest
     needs: [prettier, editorconfig, nf-test-changes, lint-modules, lint-subworkflows, nf-test]
     if: ${{ !cancelled() }}

--- a/.github/workflows/lint_module.yml
+++ b/.github/workflows/lint_module.yml
@@ -29,7 +29,7 @@ run-name: Lint ${{ inputs.component }}
 jobs:
   nf-core-lint:
     runs-on: ubuntu-latest
-    name: nf-core-lint-${{ inputs.component }}
+    name: lint - ${{ inputs.component }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nf-test_module.yml
+++ b/.github/workflows/nf-test_module.yml
@@ -44,7 +44,7 @@ run-name: Run nf-test on ${{ inputs.paths }}
 jobs:
   nf-test:
     runs-on: ${{ inputs.runner }}
-    name: nf-test-${{ inputs.paths }}
+    name: test - ${{ inputs.paths || 'skipped' }}
     if: inputs.paths != '' && inputs.profile != ''
     env:
       NXF_ANSI_LOG: false

--- a/.github/workflows/nf-test_module.yml
+++ b/.github/workflows/nf-test_module.yml
@@ -69,6 +69,10 @@ jobs:
         with:
           version: ${{ env.NFTEST_VER }}
 
+      - name: Fix nf-test launching jvm with too much memory
+        run: |
+          sed -i 's/-Xmx10g//' $(which nf-test)
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

We haven't encountered the bug per say on `main`, but I did bust the `runners` memory a few time, because `nf-test` lets its `jvm` acquire `10Gb` of RAM, even if the resources are not available. This adds a step to the test workflow to patch the `nf-test` executable so RAM doesn't bust.

## Steps to reproduce the bug

I won't provide steps as it is a bit techy to test, but am happy to discuss about it.
