### PR TITLE
[IMPROV] Allow workflows to run on forks, except for test targets

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,70 @@
+reviewers:
+  defaults:
+    - repository-owners
+    - team:Reviewers_nf-scil
+    - AlexVCaron
+
+  groups:
+    repository-owners:
+      - AlexVCaron
+      - arnaudbore
+    infrastructure-leads:
+      - AlexVCaron
+    testing-leads:
+      - AlexVCaron
+    documentation-leads:
+      - team:Reviewers_nf-scil
+    surgery-leads:
+      - GuillaumeTh
+    diffusion-mri-leads:
+      - GuillaumeTh
+      - AlexVCaron
+
+  per_author:
+    anroy1:
+      - GuillaumeTh
+      - surgery-leads
+      - diffusion-mri-leads
+
+files:
+  '**':
+    - infrastructure-leads
+  '.devcontainer/**':
+    - infrastructure-leads
+  '.github/**':
+    - infrastructure-leads
+  '.github/ISSUE_TEMPLATE/**':
+    - infrastructure-leads
+    - documentation-leads
+  '.github/PULL_REQUEST_TEMPLATE/**':
+    - infrastructure-leads
+    - documentation-leads
+  '.github/pull_request_template.md':
+    - infrastructure-leads
+    - documentation-leads
+  '.vscode/**':
+    - infrastructure-leads
+  'nf-scil-extensions/**':
+    - infrastructure-leads
+  'tests/**':
+    - testing-leads
+  'docs/**':
+    - documentation-leads
+  'modules/nf-scil/**':
+    - team:Reviewers_nf-scil
+  'subworkflows/nf-scil/**':
+    - team:Reviewers_nf-scil
+  'LICENSE':
+    - repository-owners
+  'CONTRIBUTING.md':
+    - repository-owners
+    - documentation-leads
+
+options:
+  ignore_draft: true
+  ignored_keywords:
+    - WIP
+    - Work in progress
+  enable_group_assignments: true
+  number_of_reviewers: 2
+  last_files_match_only: false

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -116,7 +116,7 @@ jobs:
   nf-test:
     name: test
     needs: [nf-test-changes]
-    if: github.repository == 'scilus/nf-scil' && ${{ ( needs.nf-test-changes.outputs.paths != '[]' ) }}
+    if: ${{ ( github.repository == 'scilus/nf-scil' ) && ( needs.nf-test-changes.outputs.paths != '[]' ) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -116,7 +116,7 @@ jobs:
   nf-test:
     name: test
     needs: [nf-test-changes]
-    if: ${{ ( needs.nf-test-changes.outputs.paths != '[]' ) }}
+    if: github.repository == 'scilus/nf-scil' && ${{ ( needs.nf-test-changes.outputs.paths != '[]' ) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/review_assignment.yml
+++ b/.github/workflows/review_assignment.yml
@@ -8,6 +8,7 @@ jobs:
   assign-reviewers:
     name: Assign reviewers
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'scilus/nf-scil' }}
     steps:
       - uses: necojackarc/auto-request-review@v0.13.0
         with:

--- a/.github/workflows/review_assignment.yml
+++ b/.github/workflows/review_assignment.yml
@@ -1,0 +1,15 @@
+name: Assign PR reviewers
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  assign-reviewers:
+    name: Assign reviewers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: necojackarc/auto-request-review@v0.13.0
+        with:
+          config: .github/reviewers.yml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_main.yml
+++ b/.github/workflows/update_main.yml
@@ -11,6 +11,5 @@ concurrency:
 
 jobs:
   checks:
-    if: github.repository == 'scilus/nf-scil'
     uses: ./.github/workflows/checks.yml
     secrets: inherit

--- a/.github/workflows/update_pr.yml
+++ b/.github/workflows/update_pr.yml
@@ -16,6 +16,5 @@ concurrency:
 
 jobs:
   checks:
-    if: github.repository == 'scilus/nf-scil'
     uses: ./.github/workflows/checks.yml
     secrets: inherit


### PR DESCRIPTION
## Type of improvement

**If submitting a new module or fixing a bug, please use the appropriate template.**

- [ ] Documentation
- [x] Development tools (e.g. linter, formatter, etc.)
- [ ] Development container
- [ ] Global update (please specify)
- [ ] Other (please specify)

## Describe your improvement

Remove the restrictions on `update_pr` and `update_main` workflows to allow them to run on other repos than `scilus/nf-scil`. Still, block execution of the test sub-workflow so self-hosted runners aren't used.

## Describe how to test your improvement

1. Create a fork
2. Rebase your fork's branch on this PR
3. Push online and open a PR ON YOUR FORK
4. Check that the workflow triggers and that the tests are skipped

## Checklist before requesting a review

- [x] Ensure the syntax is correct (**EditorConfig** and **Prettier** must pass)
- [x] Run the test suites if your changes affect any module
- [x] Regenerate the **Poetry** lock file if you have updated the dependencies
- [x] Ensure the documentation is up-to-date
