### PR TITLE
[FIX] Prettier inside the devcontainer doesn't work

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,35 +53,38 @@
     "customizations": {
         "vscode": {
             "settings": {
-                "python.analysis.exclude": [
-                    "${containerWorkspaceFolder}/.dvc",
-                    "${containerWorkspaceFolder}/.pytest_cache",
-                    "${containerWorkspaceFolder}/.test_data",
-                    "${containerWorkspaceFolder}/.vscode",
-                    "${containerWorkspaceFolder}/.venv",
-                    "${containerWorkspaceFolder}/nf-scil-extensions",
-                    "**/__pycache__",
-                    "${containerWorkspaceFolder}/.git"
-                ],
-                "python.analysis.ignore": [
-                    "${containerWorkspaceFolder}/.dvc",
-                    "${containerWorkspaceFolder}/.pytest_cache",
-                    "${containerWorkspaceFolder}/.test_data",
-                    "${containerWorkspaceFolder}/.vscode",
-                    "${containerWorkspaceFolder}/.venv",
-                    "${containerWorkspaceFolder}/nf-scil-extensions",
-                    "**/__pycache__",
-                    "${containerWorkspaceFolder}/.git"
-                ],
-                "python.createEnvironment.trigger": "off",
-                "python.interpreter.infoVisibility": "always",
-                "python.poetryPath": "poetry",
-                "python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv",
-                "python.terminal.activateEnvironment": true,
-                "python.terminal.activateEnvInCurrentTerminal": true,
-                "python.terminal.focusAfterLaunch": true,
-                "pythonIndent.keepHangingBracketOnLine": true,
-                "pythonIndent.trimLinesWithOnlyWhitespace": true
+                "[prettier]": {
+                    "prettierPath": "/usr/lib/node_modules/prettier"
+                },
+                "[python]": {
+                    "analysis.exclude": [
+                        "${containerWorkspaceFolder}/.dvc",
+                        "${containerWorkspaceFolder}/.pytest_cache",
+                        "${containerWorkspaceFolder}/.test_data",
+                        "${containerWorkspaceFolder}/.vscode",
+                        "${containerWorkspaceFolder}/.venv",
+                        "${containerWorkspaceFolder}/nf-scil-extensions",
+                        "**/__pycache__",
+                        "${containerWorkspaceFolder}/.git"
+                    ],
+                    "analysis.ignore": [
+                        "${containerWorkspaceFolder}/.dvc",
+                        "${containerWorkspaceFolder}/.pytest_cache",
+                        "${containerWorkspaceFolder}/.test_data",
+                        "${containerWorkspaceFolder}/.vscode",
+                        "${containerWorkspaceFolder}/.venv",
+                        "${containerWorkspaceFolder}/nf-scil-extensions",
+                        "**/__pycache__",
+                        "${containerWorkspaceFolder}/.git"
+                    ],
+                    "createEnvironment.trigger": "off",
+                    "interpreter.infoVisibility": "always",
+                    "poetryPath": "/root/.local/bin/poetry",
+                    "defaultInterpreterPath": "${containerWorkspaceFolder}/.venv",
+                    "terminal.activateEnvironment": true,
+                    "terminal.activateEnvInCurrentTerminal": true,
+                    "terminal.focusAfterLaunch": true
+                }
             },
             "extensions": [
                 "AlexVCaron.nf-scil-extensions",

--- a/.github/workflows/review_assignment.yml
+++ b/.github/workflows/review_assignment.yml
@@ -8,6 +8,8 @@ jobs:
   assign-reviewers:
     name: Assign reviewers
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: ${{ github.repository == 'scilus/nf-scil' }}
     steps:
       - uses: necojackarc/auto-request-review@v0.13.0


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

Prettier is not running inside of the container. In fact, the whole settings section in the `devcontainer.json` file wasn't applied. This fixes it all.

## Steps to reproduce the bug

A. On the main branch
1. Delete the `node_modules` folder in the workspace if present.
2. Rebuild the container
3. Open any `.nf` file, the icon for prettier in the lower right corner should be red, indicating prettier is bugged
B. On this PR
1. Rebuild the container
2. Open any `.nf` file, the icon for prettier in the lower right corner should be gray, with two check marks
